### PR TITLE
Add Region.destroy()

### DIFF
--- a/src/core/classes/Region.js
+++ b/src/core/classes/Region.js
@@ -82,10 +82,10 @@ class Region {
     }
 
     // Bind detected browser events to the region element.
-    eventNames.map((name) => {
-      element.addEventListener(name, (e) => {
-        arbiter(e, this);
-      }, this.capture);
+    this.eventHandlers = eventNames.map((name) => {
+      let fn = (e) => arbiter(e, this);
+      element.addEventListener(name, fn, this.capture);
+      return [name, fn];
     });
   }
 
@@ -212,6 +212,17 @@ class Region {
     let registeredGesture = this.state.registeredGestures[key];
     delete this.state.registeredGestures[key];
     return registeredGesture;
+  }
+
+  /* destroy */
+
+  /**
+   * Destroy a region by removing all attached event listeners
+   */
+  destroy() {
+    this.eventHandlers.forEach(([name, handler]) => {
+      this.element.removeEventListener(name, handler);
+    });
   }
 }
 

--- a/test/core/classes/Region.spec.js
+++ b/test/core/classes/Region.spec.js
@@ -44,3 +44,11 @@ describe('Region.bind(element)', function() {
     }
   });
 });
+
+/** @test {Region.destroy} */
+describe('Region.destroy()', function() {
+  let region = new Region(document.body);
+  it('should exists', function() {
+    expect(region.destroy).to.exist;
+  });
+});


### PR DESCRIPTION
This allows a region's event listeners to be removed from an element by saving all the event handlers and removing them with `.destroy()`. With the way browsers handle event listeners, I didn't see a great way to test this. I'm open to suggestions.