### PR TITLE
Switch angular measurement from degrees to radians

### DIFF
--- a/src/core/util.js
+++ b/src/core/util.js
@@ -77,6 +77,7 @@ let util = {
       y: ((y0 + y1) / 2),
     };
   },
+
   /**
    * Calculates the angle between the projection and an origin point.
    *   |                (projectionX,projectionY)
@@ -90,28 +91,22 @@ let util = {
    * @param {number} originY
    * @param {number} projectionX
    * @param {number} projectionY
-   * @return {number} - Degree along the unit circle where the project lies
+   * @return {number} - Radians along the unit circle where the projection lies
    */
   getAngle(originX, originY, projectionX, projectionY) {
-    let angle = Math.atan2(projectionY - originY, projectionX - originX) *
-      ((HALF_CIRCLE_DEGREES) / Math.PI);
-    return CIRCLE_DEGREES - ((angle < 0) ? (CIRCLE_DEGREES + angle) : angle);
+    return Math.atan2(projectionY - originY, projectionX - originX);
   },
+
   /**
-   * Calculates the angular distance in degrees between two angles
-   *  along the unit circle
-   * @param {number} start - The starting point in degrees
-   * @param {number} end - The ending point in degrees
-   * @return {number} The number of degrees between the
-   * starting point and ending point. Negative degrees denote a clockwise
-   * direction, and positive a counter-clockwise direction.
+   * Calculates the angular distance in radians between two angles along the
+   * unit circle
+   * @param {number} start - The starting point in radians
+   * @param {number} end - The ending point in radians
+   * @return {number} The number of radians between the starting point and
+   * ending point. 
    */
   getAngularDistance(start, end) {
-    let angle = (end - start) % CIRCLE_DEGREES;
-    let sign = (angle < 0) ? 1 : -1;
-    angle = Math.abs(angle);
-    return (angle > HALF_CIRCLE_DEGREES) ?
-    sign * (CIRCLE_DEGREES - angle) : sign * angle;
+    return end - start;
   },
 
   /**

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -3,9 +3,6 @@
  * Various accessor and mutator functions to handle state and validation.
  */
 
-const CIRCLE_DEGREES = 360;
-const HALF_CIRCLE_DEGREES = 180;
-
 /**
  *  Contains generic helper functions
  * @type {Object}

--- a/test/core/util.spec.js
+++ b/test/core/util.spec.js
@@ -68,34 +68,36 @@ describe('util.distanceBetweenTwoPoints', function() {
 
 /** @test {util.getAngle} */
 describe('util.getAngle', function() {
-  it('should return an angle of 45', function() {
-    expect(util.getAngle(0, 0, 3, 3)).to.equal(315);
+  it('should return an angle of PI/4', function() {
+    expect(util.getAngle(0, 0, 3, 3)).to.equal(Math.PI / 4);
   });
 
-  it('should return an angle of 360', function() {
-    expect(util.getAngle(0, 0, 0, 0)).to.equal(360);
+  it('should return an angle of 0', function() {
+    expect(util.getAngle(0, 0, 0, 0)).to.equal(0);
   });
 
-  it('should return an angle of 180', function() {
-    expect(util.getAngle(0, 0, -3, 0)).to.equal(180);
+  it('should return an angle of PI', function() {
+    expect(util.getAngle(0, 0, -3, 0)).to.equal(Math.PI);
   });
 });
 
 /** @test {util.getAngularDistance} */
 describe('util.getAngularDistance', function() {
-  it('should return an angle of 45', function() {
-    expect(util.getAngularDistance(270, 360)).to.equal(-90);
+  it('should return an angle of PI / 2', function() {
+    expect(util.getAngularDistance(Math.PI * 3/2, Math.PI * 2)).to.equal(
+      Math.PI / 2
+    );
   });
 
-  it('should return an angle of -15', function() {
-    expect(util.getAngularDistance(5, 350)).to.equal(-15);
+  it('should return an angle of PI', function() {
+    expect(util.getAngularDistance(0, Math.PI)).to.equal(Math.PI);
   });
 
-  it('should return an angle of +15', function() {
-    expect(util.getAngularDistance(350, 5)).to.equal(15);
+  it('should return an angle of -PI', function() {
+    expect(util.getAngularDistance(Math.PI, 0)).to.equal(-Math.PI);
   });
 
   it('should return an angle of 0', function() {
-    expect(util.getAngularDistance(360, 360)).to.equal(0);
+    expect(util.getAngularDistance(Math.PI, Math.PI)).to.equal(0);
   });
 });


### PR DESCRIPTION
- Removes conversions from radians to degrees in angular calculations.
- Simplify the angular calculations.
- Update tests accordingly.

I think this is everything in the actual source that is affected by the switch. Documentation and examples would still need to be updated though.